### PR TITLE
DO NOT MERGE: Update librdkafka to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     racecar (2.6.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.10.0)
+      rdkafka (~> 0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -28,10 +28,10 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)
-    rdkafka (0.10.0)
-      ffi (~> 1.9)
-      mini_portile2 (~> 2.1)
-      rake (>= 12.3)
+    rdkafka (0.11.1)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -64,4 +64,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.3.0
+   2.3.4

--- a/racecar.gemspec
+++ b/racecar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_runtime_dependency "king_konf", "~> 1.0.0"
-  spec.add_runtime_dependency "rdkafka",   "~> 0.10.0"
+  spec.add_runtime_dependency "rdkafka",   "~> 0.11.0"
 
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Racecar 2.6.0 depends on [rdkafka-ruby](https://github.com/appsignal/rdkafka-ruby) 0.10, which depends on [librdkafka](https://github.com/edenhill/librdkafka) 1.5.0. This version of the underlying librdkafka library does not support the cooperative-sticky partition assignment strategy for consumers.

Bumping rdkafka-ruby to 0.11 pulls in librdkafka 1.8.2, which includes support for incremental rebalances using cooperative sticky partition assignment. The Zendesk team already has an open PR (https://github.com/zendesk/racecar/pull/274) against the main repo with the rdkafka upgrade (amongst other things). We should abandon this fork as soon as those changes are released.