### PR TITLE
Include topic/partition for acknowledged messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gemspec
 # We actually support version 6.0 (see gemspec); this extra restriction is added just for running the test suite also
 # on Ruby 2.4, which activesupport 6.0 no longer supports
 gem 'activesupport', '< 6.0'
+
+gem 'rdkafka', github: 'aha-app/rdkafka-ruby', branch: 'include-topic-on-delivery-report'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/aha-app/rdkafka-ruby.git
+  revision: 926b26d0a02e63f7e611b17b2182fc5a11d7048e
+  branch: include-topic-on-delivery-report
+  specs:
+    rdkafka (0.12.0)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+
 PATH
   remote: .
   specs:
@@ -27,11 +37,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rake (13.0.1)
-    rdkafka (0.12.0)
-      ffi (~> 1.15)
-      mini_portile2 (~> 2.6)
-      rake (> 12)
+    rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -60,8 +66,9 @@ DEPENDENCIES
   pry
   racecar!
   rake (> 10.0)
+  rdkafka!
   rspec (~> 3.0)
   timecop
 
 BUNDLED WITH
-   2.3.7
+   2.3.21

--- a/lib/racecar/datadog.rb
+++ b/lib/racecar/datadog.rb
@@ -239,7 +239,11 @@ module Racecar
       end
 
       def acknowledged_message(event)
-        tags = { client: event.payload.fetch(:client_id) }
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+          partition: event.payload.fetch(:partition)
+        }
 
         # Number of messages ACK'd for the topic.
         increment("producer.ack.messages", tags: tags)

--- a/lib/racecar/rails_config_file_loader.rb
+++ b/lib/racecar/rails_config_file_loader.rb
@@ -26,7 +26,11 @@ module Racecar
           console = ActiveSupport::Logger.new($stdout)
           console.formatter = Rails.logger.formatter
           console.level = Rails.logger.level
-          Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
+          if ::Rails::VERSION::STRING < "7.1"
+            Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
+          else
+            Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, console)
+          end
         end
       end
     end

--- a/lib/racecar/runner.rb
+++ b/lib/racecar/runner.rb
@@ -159,7 +159,8 @@ module Racecar
       ->(delivery_report) do
         payload = {
           offset: delivery_report.offset,
-          partition: delivery_report.partition
+          partition: delivery_report.partition,
+          topic: delivery_report.topic_name
         }
         @instrumenter.instrument("acknowledged_message", payload)
       end

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -380,14 +380,18 @@ RSpec.describe Racecar::Datadog::ProducerSubscriber do
   describe '#acknowledged_message' do
     let(:event) do
       create_event(
-        'deliver_messages',
+        'acknowledged_message',
         client_id: 'racecar',
-        delivered_message_count: 10
+        offset: 123,
+        partition: 1,
+        topic: 'test_topic'
       )
     end
     let(:metric_tags) do
       %w[
           client:racecar
+          topic:test_topic
+          partition:1
         ]
     end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -198,7 +198,7 @@ class FakeDeliveryHandle
   end
 
   def create_result
-    Rdkafka::Producer::DeliveryReport.new(partition, offset)
+    Rdkafka::Producer::DeliveryReport.new(partition, offset, topic_name)
   end
 
   def offset
@@ -207,6 +207,10 @@ class FakeDeliveryHandle
 
   def partition
     0
+  end
+
+  def topic_name
+    @msg.topic
   end
 end
 
@@ -688,7 +692,7 @@ RSpec.describe Racecar::Runner do
       runner.run
 
       expect(instrumenter).to have_received(:instrument)
-        .with("acknowledged_message", {partition: 0, offset: 0})
+        .with("acknowledged_message", {partition: 0, offset: 0, topic: "doubled"})
     end
   end
 


### PR DESCRIPTION
It would be helpful to be able to fliter by topic and partition for `producer.ack.messages` in Datadog. This requires changes to the rdkafka gem to add the topic name to the delivery report: https://github.com/appsignal/rdkafka-ruby/pull/215.

Eventually, we'd like to contribute this change back to the main zendesk repo, but it currently depends on our fork of rdkafka-ruby.